### PR TITLE
WORK_DIR parameter and optional deployment of 'oc'

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -30,3 +30,15 @@ elif [[ -e requirements.txt ]]; then
   pip install --user -r requirements.txt
 fi
 
+if [[ -v INSTALL_OC ]]; then
+  echo "---> Installing 'oc' binary..."
+  mkdir tmp
+  cd tmp
+  curl -L ${OC_BINARY_URL} -o openshift-client.tar.gz
+  OC_PATH=`tar -tzf openshift-client.tar.gz |grep oc`
+  tar -xzf openshift-client.tar.gz ${OC_PATH}
+  cp ${OC_PATH} ${APP_ROOT}/bin/oc
+  cd ..
+  rm -rf tmp/
+fi
+

--- a/.s2i/bin/run
+++ b/.s2i/bin/run
@@ -24,6 +24,8 @@ elif [[ -v INVENTORY_URL ]]; then
 elif [[ -v DYNAMIC_SCRIPT_URL ]]; then
   curl -o ${INVENTORY} ${DYNAMIC_SCRIPT_URL}
   chmod 755 ${INVENTORY}
+else
+  INVENTORY_ARG=""
 fi
 
 if [[ "$ALLOW_ANSIBLE_CONNECTION_LOCAL" = false ]]; then
@@ -36,5 +38,8 @@ if [[ -v VAULT_PASS ]]; then
   VAULT_PASS_ARG="--vault-password-file ${VAULT_PASS_FILE}"
 fi
 
+WORK_DIR=${WORK_DIR:-${APP_HOME}}
+
+cd ${WORK_DIR}
 ansible-playbook ${INVENTORY_ARG} ${VAULT_PASS_ARG} ${OPTS} ${PLAYBOOK_FILE}
 #set +x

--- a/.s2i/bin/run
+++ b/.s2i/bin/run
@@ -15,7 +15,7 @@ USER_ID=$(id -u)
 GROUP_ID=$(id -g)
 sed "s@${USER_NAME}:x:\${USER_ID}:\${GROUP_ID}@${USER_NAME}:x:${USER_ID}:${GROUP_ID}@g" ${APP_ROOT}/etc/passwd.template > /etc/passwd
 
-INVENTORY="tmp_inventory"
+INVENTORY="${APP_HOME}/tmp_inventory"
 INVENTORY_ARG="-i ${INVENTORY}"
 if [[ -v INVENTORY_FILE ]]; then
   cp ${INVENTORY_FILE} ${INVENTORY}

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,14 +29,15 @@ COPY user_setup /tmp
 
 ENV APP_ROOT=/opt/app-root \
     USER_NAME=default \
-    USER_UID=1001
+    USER_UID=1001 \
+    OC_BINARY_URL='https://github.com/openshift/origin/releases/download/v1.4.1/openshift-origin-client-tools-v1.4.1-3f9807a-linux-64bit.tar.gz'
 ENV APP_HOME=${APP_ROOT}/src  PATH=$PATH:${APP_ROOT}/bin
 RUN mkdir -p ${APP_HOME} ${APP_ROOT}/etc ${APP_ROOT}/bin
 RUN chmod -R ug+x ${APP_ROOT}/bin ${APP_ROOT}/etc /tmp/user_setup && \
     /tmp/user_setup
 
 # This default user is created in the openshift/base-centos7 image
-USER ${USER_UID} 
+USER ${USER_UID}
 
 RUN sed "s@${USER_NAME}:x:${USER_UID}:0@${USER_NAME}:x:\${USER_ID}:\${GROUP_ID}@g" /etc/passwd > ${APP_ROOT}/etc/passwd.template
 CMD ["run"]

--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ ansible-vault passphrase for decrypting files. This is written to a file and use
 
 Disable host key checking. See [documentation](http://docs.ansible.com/ansible/intro_getting_started.html#host-key-checking)
 
+`INSTALL_OC` (optional, build-time variable)
+
+If specified during build (e.g. `oc new-build -e INSTALL_OC=true ...`) the `oc`
+[OpenShift client](https://docs.openshift.org/latest/cli_reference/index.html)
+binary is downloaded and installed into the resulting image.
+
 ## Contribute
 
 **S2I project documentation**

--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ If specified during build (e.g. `oc new-build -e INSTALL_OC=true ...`) the `oc`
 [OpenShift client](https://docs.openshift.org/latest/cli_reference/index.html)
 binary is downloaded and installed into the resulting image.
 
+`WORK_DIR` (optional)
+
+If not specified `ansible-playbook` will run from `${APP_HOME}`
+directory(`/opt/app-root/src`) where the target repository is mounted.
+When relative or absolute path is specified in `WORK_DIR`, `ansible-playbook`
+will be launched from `WORK_DIR` directory. That might come in handy for
+example if you have roles or `ansible.cfg` in non-root of the repository.
+
 ## Contribute
 
 **S2I project documentation**

--- a/test/run
+++ b/test/run
@@ -48,6 +48,10 @@ run_s2i_build() {
   s2i build --incremental=true ${s2i_args} file://${test_dir}/test-app ${IMAGE_NAME} ${IMAGE_NAME}-testapp
 }
 
+run_s2i_oc_build() {
+  s2i build --incremental=true ${s2i_args} -e INSTALL_OC=true file://${test_dir}/test-app ${IMAGE_NAME} ${IMAGE_NAME}-testapp-oc
+}
+
 prepare() {
   if ! image_exists ${IMAGE_NAME}; then
     echo "ERROR: The image ${IMAGE_NAME} must exist before this script is executed."
@@ -67,6 +71,11 @@ run_test_application() {
   docker run --rm --cidfile=${cid_file} -e ANSIBLE_HOST_KEY_CHECKING=False -e OPTS="-vvv -u 1001 --connection local" -e INVENTORY_FILE=inventory -e PLAYBOOK_FILE=test-playbook.yaml ${IMAGE_NAME}-testapp
 }
 
+run_test_oc_application() {
+  #docker run --rm --cidfile=${cid_file} -e ANSIBLE_HOST_KEY_CHECKING=False -e OPTS="-vvv --become --private-key id_rsa" -e INVENTORY_FILE=inventory -e PLAYBOOK_FILE=test-playbook.yaml ${IMAGE_NAME}-testapp
+  docker run --rm --cidfile=${cid_file} -e ANSIBLE_HOST_KEY_CHECKING=False -e OPTS="-vvv -u 1001 --connection local" -e INVENTORY_FILE=inventory -e PLAYBOOK_FILE=test-oc-playbook.yaml ${IMAGE_NAME}-testapp-oc
+}
+
 cleanup() {
   if [ -f $cid_file ]; then
     if container_exists; then
@@ -76,6 +85,10 @@ cleanup() {
   if image_exists ${IMAGE_NAME}-testapp; then
     docker rmi ${IMAGE_NAME}-testapp
   fi
+  if image_exists ${IMAGE_NAME}-testapp-oc; then
+    docker rmi ${IMAGE_NAME}-testapp-oc
+  fi
+  rm ${cid_file}
 }
 
 check_result() {
@@ -153,6 +166,14 @@ wait_for_cid
 # for this application we're not exposing a service so this isn't relevant
 #test_connection
 #check_result $?
+
+cleanup
+
+run_s2i_oc_build
+check_result $?
+
+run_test_oc_application
+check_result $?
 
 cleanup
 

--- a/test/test-app/test-oc-playbook.yaml
+++ b/test/test-app/test-oc-playbook.yaml
@@ -1,0 +1,7 @@
+---
+- name: Hello Ansible - quick start
+  hosts: local-test
+
+  tasks:
+    - name: Hello server
+      shell: oc version


### PR DESCRIPTION
`INSTALL_OC` env var deploys `oc` into the image.
If `WORK_DIR` env var is specified ansible-playbook will run from that directory (relative to ${APP_HOME} or absolute). that allows ansible to pick up `ansible.cfg` if present.