### PR TITLE
Fix path references

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,4 +40,4 @@ RUN chmod -R ug+x ${APP_ROOT}/bin ${APP_ROOT}/etc /tmp/user_setup && \
 USER ${USER_UID}
 
 RUN sed "s@${USER_NAME}:x:${USER_UID}:0@${USER_NAME}:x:\${USER_ID}:\${GROUP_ID}@g" /etc/passwd > ${APP_ROOT}/etc/passwd.template
-CMD ["usage"]
+CMD ["/usr/libexec/s2i/usage"]

--- a/Dockerfile.example
+++ b/Dockerfile.example
@@ -3,12 +3,14 @@
 FROM docker.io/aweiteka/playbook2image:latest
 
 # OPTIONAL:
-#ADD your_dynamic_inventory_script.py requirements.txt /opt/app-root/src/
-#RUN pip install -r /opt/app-root/src/requirements.txt
+#ADD your_dynamic_inventory_script.py requirements.txt ${APP_HOME}
+#RUN pip install -r ${APP_HOME}/requirements.txt
 
 # uncomment if your playbook needs the oc CLI
 #ENV INSTALL_OC=true
 
-ADD YOUR_PLAYBOOK /opt/app-root/src/
+ADD YOUR_PLAYBOOK ${APP_HOME}
 
-CMD ["run"]
+# Containers from the built image should invoke the default "run" script
+# provided by the base image
+CMD ["/usr/libexec/s2i/run"]


### PR DESCRIPTION
The s2i scripts are not in $PATH so they must be called with full path.

Also, use existing environment variables for $APP_HOME when referencing it.