### PR TITLE
Automate the URL of OC_BINARY_URL

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -31,9 +31,11 @@ elif [[ -e requirements.txt ]]; then
 fi
 
 if [[ -v INSTALL_OC ]]; then
+  pip install --user requests
   echo "---> Installing 'oc' binary..."
   mkdir tmp
   cd tmp
+  OC_BINARY_URL=$(python -c "import requests;print [s for s in [r for r in requests.get('https://api.github.com/repos/openshift/origin/releases').json() if not r['prerelease'] and '1.4' in r['name']][0]['assets'] if 'linux-64' in s['browser_download_url']][0]['browser_download_url']")
   curl -L ${OC_BINARY_URL} -o openshift-client.tar.gz
   OC_PATH=`tar -tzf openshift-client.tar.gz |grep oc`
   tar -xzf openshift-client.tar.gz ${OC_PATH}

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,6 @@ ADD README.md /help.1
 ENV APP_ROOT=/opt/app-root \
     USER_NAME=default \
     USER_UID=1001 \
-    OC_BINARY_URL='https://github.com/openshift/origin/releases/download/v1.4.1/openshift-origin-client-tools-v1.4.1-3f9807a-linux-64bit.tar.gz'
 ENV APP_HOME=${APP_ROOT}/src  PATH=$PATH:${APP_ROOT}/bin
 RUN mkdir -p ${APP_HOME} ${APP_ROOT}/etc ${APP_ROOT}/bin
 RUN chmod -R ug+x ${APP_ROOT}/bin ${APP_ROOT}/etc /tmp/user_setup && \


### PR DESCRIPTION
Adds a python one-liner using the GitHub API to determine the latest release of OpenShift 1.4.
Removes the static OC_BINARY_URL from the Dockerfile.

Testing
```
Cloning "https://github.com/jcpowermac/playbook2image-example" ...
        Commit: 98ea4e0008baf13f5a7e67bc5ad23357cc47ab7d (Updated schedule section removing names)
        Author: Joseph Callen <jcpowermac@gmail.com>
        Date:   Thu Feb 2 09:42:11 2017 -0500

---> Installing application source...
---> Building application from source...
Collecting requests
Downloading requests-2.13.0-py2.py3-none-any.whl (584kB)
Installing collected packages: requests
Successfully installed requests
You are using pip version 8.1.2, however version 9.0.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
---> Installing 'oc' binary...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   639    0   639    0     0   1489      0 --:--:-- --:--:-- --:--:--  1492
100 22.3M  100 22.3M    0     0  3903k      0  0:00:05  0:00:05 --:--:-- 5218k
tar: Ignoring unknown extended header keyword `LIBARCHIVE.xattr.security.selinux'
tar: Ignoring unknown extended header keyword `LIBARCHIVE.xattr.security.selinux'
tar: Ignoring unknown extended header keyword `LIBARCHIVE.xattr.security.selinux'
tar: Ignoring unknown extended header keyword `LIBARCHIVE.xattr.security.selinux'
tar: Ignoring unknown extended header keyword `LIBARCHIVE.xattr.security.selinux'
tar: Ignoring unknown extended header keyword `LIBARCHIVE.xattr.security.selinux'

Pushing image 172.30.7.246:5000/playbook2image/playbook2image-example:latest ...
Pushed 0/14 layers, 0% complete
Pushed 1/14 layers, 7% complete
Push successful

```