### PR TITLE
Dockerfile.example improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ In this workflow we build a new image with our playbook, setup secrets (private 
   * Using OpenShift:
     1. Create a secret for our ssh private key
 
-            oc secrets new-sshauth sshkey --ssh-privatekey=~/.ssh/id_rsa
+            oc secrets new-sshauth sshkey --ssh-privatekey=$HOME/.ssh/id_rsa
     1. Create a new job. Download the [sample-job.yaml](https://raw.githubusercontent.com/aweiteka/playbook2image/master/examples/sample-job.yaml) file, edit and create the job.
 
             oc create -f sample-job.yaml

--- a/examples/Dockerfile.example
+++ b/examples/Dockerfile.example
@@ -1,14 +1,31 @@
 # An example Dockerfile to package playbooks as docker image
-# If using OpenShift, consider using the platform source2image build instead
+# If using OpenShift, consider using the platform's source2image build instead
+
 FROM docker.io/aweiteka/playbook2image:latest
 
-# OPTIONAL:
+# -------------------------------------------------------------------------
+# OPTIONAL: dependencies
+#
+# You might want to install some additional dependencies that your playbook
+# needs.
+#
+# You can, of course, bring them manually via ADD/RUN/etc here:
+#
 #ADD your_dynamic_inventory_script.py requirements.txt ${APP_HOME}
 #RUN pip install -r ${APP_HOME}/requirements.txt
+#
+# You can also make use of the 'assemble' script that is part of
+# playbook2image as it has built-in support for some common dependency
+# tasks. For example, to install the 'oc' command line client and 
+# some Python dependencies:
+#
+#ENV INSTALL_OC=true \
+#    PYTHON_REQUIREMENTS=pyOpenSSL
+#RUN /usr/libexec/s2i/assemble
 
-# uncomment if your playbook needs the oc CLI
-#ENV INSTALL_OC=true
 
+# -------------------------------------------------------------------------
+# REQUIRED: add your playbook (and associated roles, filters, etc)
 ADD YOUR_PLAYBOOK ${APP_HOME}
 
 # Containers from the built image should invoke the default "run" script

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,3 +16,7 @@ This directory contains a few examples of how to use playbook2image.
 - [Dockerfile.example](Dockerfile.example) is an example `Dockerfile` to build an image based on `playbook2image` using `docker build`. See the Build section of the [README](../README.md) for details on the various options to build images.
 
 - [sample-job.yaml](sample-job.yaml) is an example [Job spec](https://docs.openshift.org/latest/dev_guide/jobs.html) to run a specific playbook as a one time task. See the Run section of the [README](../README.md) for details on the various options to run images.
+
+- [sample-scheduled-job.yaml](sample-scheduled-job.yaml) is an example [ScheduledJob](https://docs.openshift.com/container-platform/3.4/dev_guide/scheduled_jobs.html) to run a regular status check of OpenShift's internal certificates' expiration dates. It uses a containerized `openshift-ansible` (see the `build-openshift-ansible.yaml` example above) to run a certificate check playbook.
+
+  Note that `ScheduledJob` has been renamed to [CronJob](https://docs.openshift.org/latest/dev_guide/cron_jobs.html) upstream.

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,6 +13,6 @@ This directory contains a few examples of how to use playbook2image.
         oc create -f build-template.yaml  # This imports the template
         oc new-app playbook2image         # This instantiates the template
 
-- [Dockerfile.example](Dockerfile.example) is an example `Dockerfile` to build an image based on `playbook2image` using `docker run`. See the Build section of the [README](../README.md) for details on the various options to build images.
+- [Dockerfile.example](Dockerfile.example) is an example `Dockerfile` to build an image based on `playbook2image` using `docker build`. See the Build section of the [README](../README.md) for details on the various options to build images.
 
 - [sample-job.yaml](sample-job.yaml) is an example [Job spec](https://docs.openshift.org/latest/dev_guide/jobs.html) to run a specific playbook as a one time task. See the Run section of the [README](../README.md) for details on the various options to run images.

--- a/examples/sample-job.yaml
+++ b/examples/sample-job.yaml
@@ -17,7 +17,7 @@ spec:
         image: 172.30.114.236:5000/some_project/atomic-host-tests
         env:
         - name: PLAYBOOK_FILE
-          value: /opt/app-root/src/playbooks/main.yaml
+          value: playbooks/main.yaml
         - name: INVENTORY_URL
           value: http://example.com/myhosts
         - name: ANSIBLE_PRIVATE_KEY_FILE

--- a/examples/sample-job.yaml
+++ b/examples/sample-job.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -22,8 +23,6 @@ spec:
           value: http://example.com/myhosts
         - name: ANSIBLE_PRIVATE_KEY_FILE
           value: /opt/app-root/src/.ssh/id_rsa/ssh-privatekey
-        - name: ANSIBLE_LOCAL_TEMP
-          value: /tmp/certcheck
         - name: ANSIBLE_HOST_KEY_CHECKING
           value: "False"
         # options to ansible-playbook https://linux.die.net/man/1/ansible-playbook
@@ -33,7 +32,7 @@ spec:
         - name: sshkey
           mountPath: /opt/app-root/src/.ssh/id_rsa
       volumes:
-        - name: sshkey
-          secret:
-            secretName: sshkey
+      - name: sshkey
+        secret:
+          secretName: sshkey
       restartPolicy: Never

--- a/examples/sample-scheduled-job.yaml
+++ b/examples/sample-scheduled-job.yaml
@@ -1,0 +1,47 @@
+# An example ScheduledJob to run a regular check of OpenShift's internal
+# certificate status.
+# The referenced image is a containerized openshift-ansible build
+# (see build-openshift-ansible.yaml for an example how to build it and
+# update the 'image' reference to the ImageStream's dockerPullSpec)
+# It also expects ssh keys to be present in a Secret named 'sshkey'
+---
+apiVersion: batch/v2alpha1  # ScheduledJob are alpha in 1.3 and are
+kind: ScheduledJob          # renamed to CronJob in k8s 1.5
+metadata:
+  name: certificate-check
+  labels:
+    app: certcheck
+spec:
+  schedule: "0 1 * * *"  # Run every day at 01:00
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          name: certificate-check
+          labels:
+            app: certcheck
+        spec:
+          containers:
+          - name: openshift-ansible
+            # imagestream or internal/external registry
+            image: 172.30.114.236:5000/my_oa_build/openshift-ansible
+            env:
+            - name: PLAYBOOK_FILE
+              value: playbooks/certificate_expiry/default.yaml
+            - name: INVENTORY_URL
+              # inventory is served by an external HTTP server
+              value: http://example.com/myhosts
+            - name: ANSIBLE_PRIVATE_KEY_FILE
+              value: /opt/app-root/src/.ssh/id_rsa/ssh-privatekey
+            - name: ANSIBLE_HOST_KEY_CHECKING
+              value: "False"
+            - name: OPTS
+              value: "-v"
+            volumeMounts:
+            - name: sshkey
+              mountPath: /opt/app-root/src/.ssh/id_rsa
+          volumes:
+          - name: sshkey
+            secret:
+              secretName: sshkey
+          restartPolicy: Never


### PR DESCRIPTION
Some additional comments in the example Dockerfile to explain options.

Note that just setting `INSTALL_OC=true` is not enough, something needs to be done at build time.