### PR TITLE
Add a Dockerfile.rhel7

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,0 +1,56 @@
+# playbook2image
+FROM rhscl/python-27-rhel7:2.7-16.11
+
+MAINTAINER Aaron Weitekamp <aweiteka@redhat.com>
+
+# TODO: Rename the builder environment variable to inform users about application you provide them
+# ENV BUILDER_VERSION 1.0
+
+LABEL io.k8s.description="Ansible playbook to image builder" \
+      io.k8s.display-name="playbook2image" \
+      io.openshift.tags="builder,ansible,playbook" \
+      url="https://github.com/aweiteka/playbook2image/blob/master/README.md" \
+      name="playbook2image" \
+      summary="Ansible playbook to image builder" \
+      description="Base image to to ship Ansible playbooks as self-executing container image." \
+      com.redhat.component="playbook2image-docker" \
+      vcs-url="https://github.com/aweiteka/playbook2image" \
+      vcs-type="git" \
+      version="0.0.1" \
+      release="1" \
+      architecture="x86_64"
+
+# Install Ansible.
+#
+# The default Dockerfile also installs 'pip' and 'python-devel' so that the
+# builder image can install Python dependencies if the playbooks need them.  In
+# the productized version these are provided by the python-27-rhel7 base image,
+# and dependencies should be packaged and installed with yum instead
+USER root
+
+# To use a subscription inside container yum command has to be run first (before
+# yum-config-manager) https://access.redhat.com/solutions/1443553
+RUN yum repolist > /dev/null && \
+    yum-config-manager --enable rhel-7-server-ose-3.4-rpms && \
+    yum install -y --setopt=tsflags=nodocs ansible && \
+    yum clean all -y
+
+COPY ./.s2i/bin/ /usr/libexec/s2i
+COPY user_setup /tmp
+ADD README.md /help.1
+
+ENV APP_ROOT=/opt/app-root \
+    USER_NAME=default \
+    USER_UID=1001 \
+    APP_HOME=${APP_ROOT}/src \
+    PATH=$PATH:${APP_ROOT}/bin
+
+RUN mkdir -p ${APP_HOME} ${APP_ROOT}/etc ${APP_ROOT}/bin
+RUN chmod -R ug+x ${APP_ROOT}/bin ${APP_ROOT}/etc /tmp/user_setup && \
+    /tmp/user_setup
+
+# Back to the UID used in the base image
+USER ${USER_UID}
+
+RUN sed "s@${USER_NAME}:x:${USER_UID}:0@${USER_NAME}:x:\${USER_ID}:\${GROUP_ID}@g" /etc/passwd > ${APP_ROOT}/etc/passwd.template
+CMD ["/usr/libexec/s2i/usage"]


### PR DESCRIPTION
A productization Dockerfile to build playbook2image from supported components.

Uses the Python s2i image as a base, which provides things like pip and devel packages. On the other hand, this also brings in some unnecessary packages; the alternative is to start with base RHEL and add only the necessary bits from s2i-base and python-s2i.