### PR TITLE
Fix Dockerfile APP_ROOT env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ COPY ./.s2i/bin/ /usr/libexec/s2i
 COPY user_setup /tmp
 ADD README.md /help.1
 
-ENV APP_ROOT=/opt/app-root \
-    USER_NAME=default \
+ENV APP_ROOT=/opt/app-root
+ENV USER_NAME=default \
     USER_UID=1001 \
     APP_HOME=${APP_ROOT}/src \
     PATH=$PATH:${APP_ROOT}/bin

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -39,8 +39,8 @@ COPY ./.s2i/bin/ /usr/libexec/s2i
 COPY user_setup /tmp
 ADD README.md /help.1
 
-ENV APP_ROOT=/opt/app-root \
-    USER_NAME=default \
+ENV APP_ROOT=/opt/app-root
+ENV USER_NAME=default \
     USER_UID=1001 \
     APP_HOME=${APP_ROOT}/src \
     PATH=$PATH:${APP_ROOT}/bin


### PR DESCRIPTION
Per [documentation](https://docs.docker.com/engine/reference/builder/#environment-replacement) the ENV syntax does not inherit changes when in the same line.
This also fixes failing unit tests.

Signed-off-by: Aaron Weitekamp <aweiteka@redhat.com>