### PR TITLE
GitHub API Fix

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -35,7 +35,7 @@ if [[ -v INSTALL_OC ]]; then
   echo "---> Installing 'oc' binary..."
   mkdir tmp
   cd tmp
-  OC_BINARY_URL=$(python -c "import requests;print [s for s in [r for r in requests.get('https://api.github.com/repos/openshift/origin/releases').json() if not r['prerelease'] and '1.4' in r['name']][0]['assets'] if 'linux-64' in s['browser_download_url']][0]['browser_download_url']")
+  OC_BINARY_URL=$(python -c "import requests;releases = requests.get('https://api.github.com/repos/openshift/origin/releases').json();print [s for s in [r for r in releases if not r['prerelease'] and '1.4' in r['name']][0]['assets'] if 'linux-64' in s['browser_download_url']][0]['browser_download_url']")
   curl -L ${OC_BINARY_URL} -o openshift-client.tar.gz
   OC_PATH=`tar -tzf openshift-client.tar.gz |grep oc`
   tar -xzf openshift-client.tar.gz ${OC_PATH}


### PR DESCRIPTION
Resolves issue #29 
Created variable outside of loops.

Build Testing:
```
> $ oc get builds                                                                                                                                                                                                                                                   [±github_api_issue ✓]
NAME                  TYPE      FROM          STATUS     STARTED             DURATION
ansible-test-job-10   Source    Git@98ea4e0   Complete   46 minutes ago      41s
ansible-test-job-11   Source    Git@98ea4e0   Complete   45 minutes ago      44s
ansible-test-job-12   Source    Git@98ea4e0   Complete   45 minutes ago      42s
ansible-test-job-13   Source    Git@98ea4e0   Complete   44 minutes ago      44s
ansible-test-job-14   Source    Git@98ea4e0   Complete   43 minutes ago      41s
ansible-test-job-15   Source    Git@98ea4e0   Complete   42 minutes ago      44s
ansible-test-job-16   Source    Git@98ea4e0   Complete   41 minutes ago      42s
ansible-test-job-17   Source    Git@98ea4e0   Complete   41 minutes ago      43s
ansible-test-job-18   Source    Git@98ea4e0   Complete   40 minutes ago      44s
ansible-test-job-19   Source    Git@98ea4e0   Complete   39 minutes ago      43s
ansible-test-job-20   Source    Git@98ea4e0   Complete   38 minutes ago      42s
ansible-test-job-21   Source    Git@98ea4e0   Complete   37 minutes ago      43s
ansible-test-job-22   Source    Git@98ea4e0   Complete   37 minutes ago      43s
ansible-test-job-23   Source    Git@98ea4e0   Complete   36 minutes ago      43s
ansible-test-job-24   Source    Git@98ea4e0   Complete   35 minutes ago      42s
ansible-test-job-25   Source    Git@98ea4e0   Complete   34 minutes ago      43s
ansible-test-job-26   Source    Git@98ea4e0   Complete   34 minutes ago      42s
ansible-test-job-27   Source    Git@98ea4e0   Complete   33 minutes ago      43s
ansible-test-job-28   Source    Git@98ea4e0   Complete   32 minutes ago      41s
ansible-test-job-29   Source    Git@98ea4e0   Complete   31 minutes ago      44s
ansible-test-job-30   Source    Git@98ea4e0   Complete   30 minutes ago      43s
ansible-test-job-31   Source    Git@98ea4e0   Complete   30 minutes ago      43s
ansible-test-job-32   Source    Git@98ea4e0   Complete   29 minutes ago      42s
ansible-test-job-33   Source    Git@98ea4e0   Complete   28 minutes ago      44s
ansible-test-job-34   Source    Git@98ea4e0   Complete   27 minutes ago      41s
ansible-test-job-35   Source    Git@98ea4e0   Complete   26 minutes ago      43s
ansible-test-job-36   Source    Git@98ea4e0   Complete   26 minutes ago      43s
ansible-test-job-37   Source    Git@98ea4e0   Complete   25 minutes ago      44s
ansible-test-job-38   Source    Git@98ea4e0   Complete   24 minutes ago      43s
ansible-test-job-39   Source    Git@98ea4e0   Complete   23 minutes ago      43s
ansible-test-job-40   Source    Git@98ea4e0   Complete   22 minutes ago      43s
ansible-test-job-41   Source    Git@98ea4e0   Complete   22 minutes ago      44s
ansible-test-job-42   Source    Git@98ea4e0   Complete   21 minutes ago      42s
ansible-test-job-43   Source    Git@98ea4e0   Complete   20 minutes ago      44s
ansible-test-job-44   Source    Git@98ea4e0   Complete   19 minutes ago      43s
ansible-test-job-45   Source    Git@98ea4e0   Complete   18 minutes ago      43s
ansible-test-job-46   Source    Git@98ea4e0   Complete   18 minutes ago      43s
ansible-test-job-47   Source    Git@98ea4e0   Complete   17 minutes ago      45s
ansible-test-job-48   Source    Git@98ea4e0   Complete   16 minutes ago      43s
ansible-test-job-49   Source    Git@98ea4e0   Complete   15 minutes ago      46s
ansible-test-job-5    Source    Git@98ea4e0   Complete   50 minutes ago      1m5s
ansible-test-job-50   Source    Git@98ea4e0   Complete   14 minutes ago      44s
ansible-test-job-51   Source    Git@98ea4e0   Complete   14 minutes ago      44s
ansible-test-job-52   Source    Git@98ea4e0   Complete   13 minutes ago      43s
ansible-test-job-53   Source    Git@98ea4e0   Complete   12 minutes ago      45s
ansible-test-job-54   Source    Git@98ea4e0   Complete   11 minutes ago      42s
ansible-test-job-55   Source    Git@98ea4e0   Complete   10 minutes ago      47s
ansible-test-job-56   Source    Git@98ea4e0   Complete   10 minutes ago      43s
ansible-test-job-57   Source    Git@98ea4e0   Complete   9 minutes ago       43s
ansible-test-job-58   Source    Git@98ea4e0   Complete   8 minutes ago       43s
ansible-test-job-59   Source    Git@98ea4e0   Complete   7 minutes ago       44s
ansible-test-job-6    Source    Git@98ea4e0   Complete   49 minutes ago      41s
ansible-test-job-60   Source    Git@98ea4e0   Complete   6 minutes ago       43s
ansible-test-job-61   Source    Git@98ea4e0   Complete   6 minutes ago       44s
ansible-test-job-62   Source    Git@98ea4e0   Complete   5 minutes ago       43s
ansible-test-job-63   Source    Git@98ea4e0   Complete   4 minutes ago       45s
ansible-test-job-64   Source    Git@98ea4e0   Complete   3 minutes ago       44s
ansible-test-job-65   Source    Git@98ea4e0   Complete   2 minutes ago       44s
ansible-test-job-7    Source    Git@98ea4e0   Complete   48 minutes ago      42s
ansible-test-job-8    Source    Git@98ea4e0   Complete   48 minutes ago      44s
ansible-test-job-9    Source    Git@98ea4e0   Complete   47 minutes ago      41s
```

```
> $ oc logs build/ansible-test-job-65                                                                                                                                                                                                                               [±github_api_issue ✓]
Cloning "https://github.com/jcpowermac/playbook2image-example" ...
        Commit: 98ea4e0008baf13f5a7e67bc5ad23357cc47ab7d (Updated schedule section removing names)
        Author: Joseph Callen <jcpowermac@gmail.com>
        Date:   Thu Feb 2 09:42:11 2017 -0500

---> Installing application source...
---> Building application from source...
Collecting requests
Downloading requests-2.13.0-py2.py3-none-any.whl (584kB)
Installing collected packages: requests
Successfully installed requests
You are using pip version 8.1.2, however version 9.0.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
---> Installing 'oc' binary...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   639    0   639    0     0   1376      0 --:--:-- --:--:-- --:--:--  1374
100 22.3M  100 22.3M    0     0  3812k      0  0:00:06  0:00:06 --:--:-- 4585k
tar: Ignoring unknown extended header keyword `LIBARCHIVE.xattr.security.selinux'
tar: Ignoring unknown extended header keyword `LIBARCHIVE.xattr.security.selinux'
tar: Ignoring unknown extended header keyword `LIBARCHIVE.xattr.security.selinux'
tar: Ignoring unknown extended header keyword `LIBARCHIVE.xattr.security.selinux'
tar: Ignoring unknown extended header keyword `LIBARCHIVE.xattr.security.selinux'
tar: Ignoring unknown extended header keyword `LIBARCHIVE.xattr.security.selinux'


Pushing image 172.30.10.223:5000/at/ansible-test-job:latest ...
Pushed 1/14 layers, 7% complete
Pushed 2/14 layers, 14% complete
Pushed 3/14 layers, 21% complete
Pushed 4/14 layers, 29% complete
Pushed 5/14 layers, 36% complete
Pushed 6/14 layers, 43% complete
Pushed 7/14 layers, 50% complete
Pushed 8/14 layers, 57% complete
Pushed 9/14 layers, 64% complete
Pushed 10/14 layers, 71% complete
Pushed 11/14 layers, 79% complete
Pushed 12/14 layers, 86% complete
Pushed 13/14 layers, 93% complete
Pushed 14/14 layers, 100% complete
Push successful
```
