### PR TITLE
Pre-create site.USER_BASE

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -24,6 +24,9 @@ echo "---> Installing application source..."
 cp -Rf /tmp/src/. ./
 
 echo "---> Building application from source..."
+# pre-create PYTHONUSERBASE/lib/*, otherwise pip creates it with mode 0700
+# which prevents containers with arbitrary UIDs to access local packages
+mkdir -p ${HOME}/.local/lib/python2.7/site-packages
 if [[ -v PYTHON_REQUIREMENTS ]]; then
   pip install -r ${PYTHON_REQUIREMENTS}
 elif [[ -e requirements.txt ]]; then


### PR DESCRIPTION
When installing packages with pip --user, the PYTHONUSERBASE/lib/* tree is created with mode 0700, which then prevents containers run with arbitrary UIDs to access the installed local packages. If the directories exist, permissions are not changed during pip install.

This is kind of a workaround/hack, but I couldn't find a way to tell `pip` to use different permissions when creating `~/.local/lib/...`...